### PR TITLE
Add .apignore file

### DIFF
--- a/.apignore
+++ b/.apignore
@@ -1,0 +1,3 @@
+/.git
+/.gitignore
+/README.md


### PR DESCRIPTION
ArchipelagoMW/Archipelago#5779 adds a `.apignore` format to exclude certain files from being included in built APWorlds. This PR adds a `.apignore` file to exclude git-related files from release artifacts.

`__pycache__` is already excluded globally, so no need to include it.